### PR TITLE
Fix correspondence between file name and content in clones (#105)

### DIFF
--- a/api/src/main/java/org/accula/api/handlers/ClonesHandler.java
+++ b/api/src/main/java/org/accula/api/handlers/ClonesHandler.java
@@ -131,7 +131,7 @@ public final class ClonesHandler {
 
     private Flux<FileEntity> getFileSnippets(final Flux<FileSnippetMarker> markers) {
         return markers
-                .flatMap(marker -> codeLoader.getFileSnippet(marker.commitSnapshot, marker.filename, marker.fromLine, marker.toLine))
+                .flatMapSequential(marker -> codeLoader.getFileSnippet(marker.commitSnapshot, marker.filename, marker.fromLine, marker.toLine))
                 .subscribeOn(codeLoadingScheduler);
     }
 

--- a/api/src/main/java/org/accula/api/handlers/ClonesHandler.java
+++ b/api/src/main/java/org/accula/api/handlers/ClonesHandler.java
@@ -131,7 +131,8 @@ public final class ClonesHandler {
 
     private Flux<FileEntity> getFileSnippets(final Flux<FileSnippetMarker> markers) {
         return markers
-                .flatMapSequential(marker -> codeLoader.getFileSnippet(marker.commitSnapshot, marker.filename, marker.fromLine, marker.toLine))
+                .flatMapSequential(marker -> codeLoader
+                        .getFileSnippet(marker.commitSnapshot, marker.filename, marker.fromLine, marker.toLine))
                 .subscribeOn(codeLoadingScheduler);
     }
 


### PR DESCRIPTION
Closes #105

The `Flux.flatMap` does not guarantee the original order of stream if flattening of inner elements performed concurrently. The `Flux.flatMapSequentially` does