### PR TITLE
Project deletion enhancement (#216)

### DIFF
--- a/api/src/main/java/org/accula/api/db/repo/ProjectRepoImpl.java
+++ b/api/src/main/java/org/accula/api/db/repo/ProjectRepoImpl.java
@@ -139,8 +139,8 @@ public final class ProjectRepoImpl implements ProjectRepo, ConnectionProvidedRep
                         .createStatement("""
                                 WITH deleted_repo AS (
                                     DELETE FROM project
-                                        WHERE id = $1 AND creator_id = $2
-                                        RETURNING github_repo_id
+                                    WHERE id = $1 AND creator_id = $2
+                                    RETURNING github_repo_id
                                 )
                                 DELETE
                                 FROM repo_github

--- a/api/src/main/java/org/accula/api/service/CloneDetectionService.java
+++ b/api/src/main/java/org/accula/api/service/CloneDetectionService.java
@@ -94,6 +94,12 @@ public final class CloneDetectionService {
         return cloneDetector(projectId).fill(files);
     }
 
+    public void dropSuffixTree(final Long projectId) {
+        cloneDetectorConfigs.remove(projectId);
+        cloneDetectors.remove(projectId);
+        log.info("Dropped suffix tree for project with id={}", projectId);
+    }
+
     private Mono<Void> fillSuffixTree(final Long projectId) {
         return fillSuffixTree(projectId, pullRepo.findByProjectIdIncludingSecondaryRepos(projectId));
     }

--- a/api/src/main/resources/db/migration/V1__create.sql
+++ b/api/src/main/resources/db/migration/V1__create.sql
@@ -55,7 +55,7 @@ CREATE TABLE IF NOT EXISTS project_repo
     project_id BIGINT NOT NULL,
     repo_id    BIGINT NOT NULL,
 
-    FOREIGN KEY (project_id) REFERENCES project (id),
+    FOREIGN KEY (project_id) REFERENCES project (id) ON DELETE CASCADE,
     FOREIGN KEY (repo_id) REFERENCES repo_github (id),
     CONSTRAINT project_repo_pk PRIMARY KEY (project_id, repo_id)
 );
@@ -96,7 +96,7 @@ CREATE TABLE IF NOT EXISTS snapshot
     branch  VARCHAR(256) NOT NULL,
 
     FOREIGN KEY (sha) REFERENCES commit (sha),
-    FOREIGN KEY (repo_id) REFERENCES repo_github (id),
+    FOREIGN KEY (repo_id) REFERENCES repo_github (id) ON DELETE CASCADE,
     CONSTRAINT snapshot_pk PRIMARY KEY (sha, repo_id, branch)
 );
 
@@ -120,7 +120,7 @@ CREATE TABLE IF NOT EXISTS pull
     author_github_id      BIGINT                   NOT NULL,
 
     FOREIGN KEY (head_snapshot_sha, head_snapshot_repo_id, head_snapshot_branch) REFERENCES snapshot (sha, repo_id, branch),
-    FOREIGN KEY (base_snapshot_sha, base_snapshot_repo_id, base_snapshot_branch) REFERENCES snapshot (sha, repo_id, branch),
+    FOREIGN KEY (base_snapshot_sha, base_snapshot_repo_id, base_snapshot_branch) REFERENCES snapshot (sha, repo_id, branch) ON DELETE CASCADE,
     FOREIGN KEY (author_github_id) REFERENCES user_github (id)
 );
 
@@ -129,7 +129,7 @@ CREATE TABLE IF NOT EXISTS pull_assignee
     pull_id     BIGINT NOT NULL,
     assignee_id BIGINT NOT NULL,
 
-    FOREIGN KEY (pull_id) REFERENCES pull (id),
+    FOREIGN KEY (pull_id) REFERENCES pull (id) ON DELETE CASCADE,
     FOREIGN KEY (assignee_id) REFERENCES user_github (id),
     CONSTRAINT pull_assignee_pk PRIMARY KEY (pull_id, assignee_id)
 );
@@ -141,7 +141,7 @@ CREATE TABLE IF NOT EXISTS snapshot_pull
     snapshot_branch  VARCHAR(256) NOT NULL,
     pull_id          BIGINT       NOT NULL,
 
-    FOREIGN KEY (snapshot_sha, snapshot_repo_id, snapshot_branch) REFERENCES snapshot (sha, repo_id, branch),
+    FOREIGN KEY (snapshot_sha, snapshot_repo_id, snapshot_branch) REFERENCES snapshot (sha, repo_id, branch) ON DELETE CASCADE,
     FOREIGN KEY (pull_id) REFERENCES pull (id) ON DELETE CASCADE,
     CONSTRAINT snapshot_pull_pk PRIMARY KEY (snapshot_sha, snapshot_repo_id, snapshot_branch, pull_id)
 );
@@ -159,7 +159,7 @@ CREATE TABLE IF NOT EXISTS clone_snippet
     to_line    INT          NOT NULL,
 
     FOREIGN KEY (commit_sha, repo_id, branch, pull_id) REFERENCES
-        snapshot_pull (snapshot_sha, snapshot_repo_id, snapshot_branch, pull_id)
+        snapshot_pull (snapshot_sha, snapshot_repo_id, snapshot_branch, pull_id) ON DELETE CASCADE
 );
 
 CREATE TABLE IF NOT EXISTS clone

--- a/api/src/test/java/org/accula/api/routers/ProjectsRouterTest.java
+++ b/api/src/test/java/org/accula/api/routers/ProjectsRouterTest.java
@@ -339,6 +339,9 @@ class ProjectsRouterTest {
         when(currentUser.get(Mockito.any()))
                 .thenReturn(Mono.just(0L));
 
+        when(projectRepo.hasAdmin(anyLong(), anyLong()))
+            .thenReturn(Mono.just(TRUE));
+
         when(projectRepo.delete(anyLong(), anyLong()))
                 .thenReturn(Mono.just(TRUE));
 


### PR DESCRIPTION
Closes #216 

1. At this moment project deletion is broken for projects with previous years repos due to absence of `CASCADE` deletion of `project_repo` table rows. So we need to fix this
2. Let's delete project repo if project deleted and no other project references the repo
3. Let's delete snapshots cascade if referenced repo is deleted
4. Let's delete pull if referenced base snapshot is deleted
5. Let's delete snapshot_pull rows if referenced snapshot deleted
6. Let's delete clones if referenced snapshot_pull deleted
7. Let's drop suffix tree for deleted project